### PR TITLE
Initialize ActiveRecord in rspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.6
+
+services:
+  - postgresql
+
 before_install: gem install bundler -v 2.1.4

--- a/activerecord-lookml.gemspec
+++ b/activerecord-lookml.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 6'
 
   spec.add_development_dependency 'activerecord', '>= 6'
+  spec.add_development_dependency 'pg', '>= 1'
 end

--- a/spec/activerecord/lookml/core_spec.rb
+++ b/spec/activerecord/lookml/core_spec.rb
@@ -1,5 +1,81 @@
+require 'models/pulse_onboarding_status'
+
 RSpec.describe ActiveRecord::LookML::Core do
   it "adds .enum_to_lookml method to ActiveRecord::Base" do
     expect(ActiveRecord::Base.enum_to_lookml).to eq ""
+  end
+
+  describe ".enum_to_lookml" do
+    let(:lookml) do
+      <<-LOOKML
+  dimension: manager_tutorial_state {
+    case: {
+        when: {
+        sql: ${TABLE}.manager_tutorial_state = 0 ;;
+        label: "start_tutorial"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 1 ;;
+        label: "explain_condition_survey"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 2 ;;
+        label: "ask_condition"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 3 ;;
+        label: "explain_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 4 ;;
+        label: "try_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 5 ;;
+        label: "request_members_to_get_started"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 6 ;;
+        label: "done_announce_to_member"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 7 ;;
+        label: "done_tutorial"
+      }
+
+    }
+  }
+
+  dimension: member_tutorial_state {
+    case: {
+        when: {
+        sql: ${TABLE}.member_tutorial_state = 0 ;;
+        label: "explain_condition_survey"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 1 ;;
+        label: "ask_condition"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 2 ;;
+        label: "explain_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 3 ;;
+        label: "try_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 4 ;;
+        label: "done_tutorial"
+      }
+
+    }
+  }
+      LOOKML
+    end
+
+    it "returns partial lookml defining dimensions for enum attributes" do
+      expect(PulseOnboardingStatus.enum_to_lookml).to eq lookml
+    end
   end
 end

--- a/spec/activerecord/lookml/core_spec.rb
+++ b/spec/activerecord/lookml/core_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe ActiveRecord::LookML::Core do
+  it "adds .enum_to_lookml method to ActiveRecord::Base" do
+    expect(ActiveRecord::Base.enum_to_lookml).to eq ""
+  end
+end

--- a/spec/models/pulse_onboarding_status.rb
+++ b/spec/models/pulse_onboarding_status.rb
@@ -1,0 +1,23 @@
+class PulseOnboardingStatus < ActiveRecord::Base
+  MANAGER_TUTORIAL_STATE_ENUM_HASH = {
+    start_tutorial: 0,
+    explain_condition_survey: 1,
+    ask_condition: 2,
+    explain_high_fives: 3,
+    try_high_fives: 4,
+    request_members_to_get_started: 5,
+    done_announce_to_member: 6,
+    done_tutorial: 7,
+  }.freeze
+
+  MEMBER_TUTORIAL_STATE_ENUM_HASH = {
+    explain_condition_survey: 0,
+    ask_condition: 1,
+    explain_high_fives: 2,
+    try_high_fives: 3,
+    done_tutorial: 4,
+  }.freeze
+
+  enum manager_tutorial_state: MANAGER_TUTORIAL_STATE_ENUM_HASH, _prefix: true
+  enum member_tutorial_state: MEMBER_TUTORIAL_STATE_ENUM_HASH, _prefix: true
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema.define(version: 2021_05_26_103300) do
+  create_table "pulse_onboarding_statuses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "company_id", null: false
+    t.integer "manager_tutorial_state"
+    t.integer "member_tutorial_state"
+    t.boolean "completed", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,14 @@
 require "bundler/setup"
+require "active_record"
 require "activerecord/lookml"
+
+DB_CONFIG = {
+  adapter: 'postgresql',
+  username: 'postgres',
+  min_messages: 'ERROR',
+}.with_indifferent_access.freeze
+
+ActiveRecord::Base.establish_connection(DB_CONFIG)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ DB_CONFIG = {
 }.with_indifferent_access.freeze
 
 ActiveRecord::Base.establish_connection(DB_CONFIG)
+load "#{File.dirname(__FILE__)}/schema.rb"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
## Why

In order to write specs of this gem, ActiveRecord must be available in specs.

## What


Add an initialization of ActiveRecord for rspec. NB: It assumes PostgreSQL at this point for simplicity.


Reference implementation: https://github.com/magnusvk/counter_culture/blob/master/spec/spec_helper.rb 