### PR TITLE
Drop ruby 2.6 support (for no strong reason)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.6
+  - 2.7
 
 services:
   - postgresql

--- a/activerecord-lookml.gemspec
+++ b/activerecord-lookml.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{[Experimental] Generate LookML}
   spec.homepage      = "https://github.com/wantedly/activerecord-lookml"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/wantedly/activerecord-lookml"


### PR DESCRIPTION
## Why

I imagine everyone uses ruby >= 2.7 by now. 

## What

Dropped ruby 2.6 support. 