### PR TITLE
Implement AR:Base.to_lookml

### DIFF
--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -102,9 +102,7 @@ view: pulse_onboarding_statuses {
   sql_table_name: `wantedly-1371.rdb.pulse_pulse_onboarding_statuses`;;
 
 #{dimensions_lookml}
-
-#{set_lookml}
-}
+#{set_lookml}}
           LOOKML
         end
 

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -79,7 +79,7 @@ module ActiveRecord
           end.join("\n")
         end
 
-        def to_lookml
+        def to_lookml(table_name_prefix: 'wantedly-1371.rdb.pulse_')
           dimensions_lookml = attribute_types.map do |attribute, type|
             attribute_type_to_dimension_lookml(attribute, type)
           end.join("\n")
@@ -99,7 +99,7 @@ module ActiveRecord
 
           <<-LOOKML
 view: pulse_onboarding_statuses {
-  sql_table_name: `wantedly-1371.rdb.pulse_pulse_onboarding_statuses`;;
+  sql_table_name: `#{table_name_prefix}#{table_name}`;;
 
 #{dimensions_lookml}
 #{set_lookml}}

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -135,7 +135,22 @@ view: pulse_onboarding_statuses {
   }
             LOOKML
           when ActiveRecord::Enum::EnumType
+            enum_values = defined_enums[attribute]
+            when_lines_lookml = enum_values.map do |label, value|
+              <<-LOOKML
+      when: {
+        sql: ${TABLE}.#{attribute} = #{value} ;;
+        label: "#{label}"
+      }
+              LOOKML
+            end.join
+
             <<-LOOKML
+  dimension: #{attribute} {
+    case: {
+#{when_lines_lookml}
+    }
+  }
             LOOKML
           else
             raise "Unknown attribute type: #{type.class}"

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -110,13 +110,17 @@ view: pulse_onboarding_statuses {
         def attribute_type_to_dimension_lookml(attribute, type)
           case type
           when ActiveModel::Type::Integer
-            primary_key_lookml = attribute == "id" ? "primary_key: yes" : nil
+            params = {
+              type: "number",
+              primary_key: attribute == "id" ? "yes" : nil,
+              sql: "${TABLE}.#{attribute} ;;"
+            }.compact
+
+            params_lookml = params.map { |k, v| "    #{k}: #{v}" }.join("\n")
 
             <<-LOOKML
   dimension: #{attribute} {
-    type: number
-    #{primary_key_lookml}
-    sql: ${TABLE}.#{attribute} ;;
+#{params_lookml}
   }
             LOOKML
           when ActiveModel::Type::Boolean

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -84,9 +84,10 @@ module ActiveRecord
             attribute_type_to_dimension_lookml(attribute, type)
           end.join("\n")
 
-          fields_lookml = attribute_types.keys.map do |attribute|
-            "      #{attribute}"
-          end.join(",\n")
+          fields = attribute_types.map do |attribute, type|
+            attribute_type_to_set_detail_field(attribute, type)
+          end.compact
+          fields_lookml = fields.map { |field| "      #{field}" }.join(",\n")
 
           set_lookml = <<-LOOKML
   set: detail {
@@ -152,6 +153,17 @@ view: pulse_onboarding_statuses {
     }
   }
             LOOKML
+          else
+            raise "Unknown attribute type: #{type.class}"
+          end
+        end
+
+        def attribute_type_to_set_detail_field(attribute, type)
+          case type
+          when ActiveModel::Type::Integer, ActiveModel::Type::Boolean, ActiveRecord::Enum::EnumType
+            attribute
+          when ActiveRecord::Type::DateTime
+            "#{attribute}_time"
           else
             raise "Unknown attribute type: #{type.class}"
           end

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         def to_lookml
           dimensions_lookml = attribute_types.map do |attribute, type|
-            attribute_type_to_lookml(attribute, type)
+            attribute_type_to_dimension_lookml(attribute, type)
           end.join("\n")
 
           fields_lookml = attribute_types.keys.map do |attribute|
@@ -108,7 +108,7 @@ view: pulse_onboarding_statuses {
         end
 
         private
-        def attribute_type_to_lookml(attribute, type)
+        def attribute_type_to_dimension_lookml(attribute, type)
           case type
           when ActiveModel::Type::Integer
             primary_key_lookml = attribute == "id" ? "primary_key: yes" : nil

--- a/spec/active_record/lookml/core_spec.rb
+++ b/spec/active_record/lookml/core_spec.rb
@@ -78,4 +78,126 @@ RSpec.describe ActiveRecord::LookML::Core do
       expect(PulseOnboardingStatus.enum_to_lookml).to eq lookml
     end
   end
+
+  describe ".to_lookml" do
+    let(:lookml) do
+      <<-LOOKML
+view: pulse_onboarding_statuses {
+  sql_table_name: `wantedly-1371.rdb.pulse_pulse_onboarding_statuses`;;
+
+  dimension: id {
+    type: number
+    primary_key: yes
+    sql: ${TABLE}.id ;;
+  }
+
+  dimension: user_id {
+    type: number
+    sql: ${TABLE}.user_id ;;
+  }
+
+  dimension: company_id {
+    type: number
+    sql: ${TABLE}.company_id ;;
+  }
+
+  dimension: manager_tutorial_state {
+    case: {
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 0 ;;
+        label: "start_tutorial"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 1 ;;
+        label: "explain_condition_survay"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 2 ;;
+        label: "ask_condition"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 3 ;;
+        label: "explain_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 4 ;;
+        label: "try_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 5 ;;
+        label: "request_members_to_get_started"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 6 ;;
+        label: "done_announce_to_member"
+      }
+      when: {
+        sql: ${TABLE}.manager_tutorial_state = 7 ;;
+        label: "done_tutorial"
+      }
+
+    }
+  }
+
+  dimension: member_tutorial_state {
+    case: {
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 0 ;;
+        label: "explain_condition_survay"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 1 ;;
+        label: "ask_condition"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 2 ;;
+        label: "explain_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 3 ;;
+        label: "try_high_fives"
+      }
+      when: {
+        sql: ${TABLE}.member_tutorial_state = 4 ;;
+        label: "done_tutorial"
+      }
+
+    }
+  }
+
+  dimension: completed {
+    type: yesno
+    sql: ${TABLE}.completed ;;
+  }
+
+  dimension_group: created_at {
+    type: time
+    sql: ${TABLE}.created_at ;;
+  }
+
+  dimension_group: updated_at {
+    type: time
+    sql: ${TABLE}.updated_at ;;
+  }
+
+  set: detail {
+    fields: [
+      id,
+      user_id,
+      company_id,
+      manager_tutorial_state,
+      member_tutorial_state,
+      completed,
+      created_at_time,
+      updated_at_time
+    ]
+  }
+}
+      LOOKML
+    end
+
+    it "returns lookml" do
+      expect(PulseOnboardingStatus.to_lookml).to eq lookml
+    end
+  end
 end

--- a/spec/active_record/lookml/core_spec.rb
+++ b/spec/active_record/lookml/core_spec.rb
@@ -109,7 +109,7 @@ view: pulse_onboarding_statuses {
       }
       when: {
         sql: ${TABLE}.manager_tutorial_state = 1 ;;
-        label: "explain_condition_survay"
+        label: "explain_condition_survey"
       }
       when: {
         sql: ${TABLE}.manager_tutorial_state = 2 ;;
@@ -143,7 +143,7 @@ view: pulse_onboarding_statuses {
     case: {
       when: {
         sql: ${TABLE}.member_tutorial_state = 0 ;;
-        label: "explain_condition_survay"
+        label: "explain_condition_survey"
       }
       when: {
         sql: ${TABLE}.member_tutorial_state = 1 ;;


### PR DESCRIPTION
## Why

It's super handy if we can generate an entire lookml view from ActiveRecord class. 

## What

Implemented `AR::Base.to_lookml` method.