### PR TITLE
Rewrite lookml string generation with classes

### DIFF
--- a/lib/active_record/lookml.rb
+++ b/lib/active_record/lookml.rb
@@ -1,5 +1,7 @@
 require 'active_support/all'
-require "active_record/lookml/version"
+require 'active_record/lookml/version'
+require 'active_record/lookml/block'
+require 'active_record/lookml/field'
 
 module ActiveRecord
   module LookML

--- a/lib/active_record/lookml.rb
+++ b/lib/active_record/lookml.rb
@@ -2,6 +2,7 @@ require 'active_support/all'
 require 'active_record/lookml/version'
 require 'active_record/lookml/block'
 require 'active_record/lookml/field'
+require 'active_record/lookml/array_field'
 
 module ActiveRecord
   module LookML

--- a/lib/active_record/lookml/array_field.rb
+++ b/lib/active_record/lookml/array_field.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  module LookML
+    class ArrayField
+      def initialize(name:, values:)
+        @name = name
+        @values = values
+      end
+
+      def to_lookml(indent_level: 0)
+        indent = '  ' * indent_level
+        lookml = "#{indent}#{@name}: [\n"
+        lookml << @values.map do |value|
+          "#{indent}  #{value}"
+        end.join(",\n")
+        lookml << "\n"
+        lookml << "#{indent}]\n"
+        lookml
+      end
+    end
+  end
+end

--- a/lib/active_record/lookml/block.rb
+++ b/lib/active_record/lookml/block.rb
@@ -14,7 +14,9 @@ module ActiveRecord
 
       def to_lookml(indent_level: 0)
         indent = '  ' * indent_level
-        lookml = "#{indent}#{@type}: #{@name} {\n"
+        lookml = "#{indent}#{@type}:"
+        lookml << " #{@name}" if @name
+        lookml << " {\n"
         @fields.each_with_index do |field, index|
           lookml << "\n" if index > 0 && field.is_a?(Block)
           lookml << field.to_lookml(indent_level: indent_level + 1)

--- a/lib/active_record/lookml/block.rb
+++ b/lib/active_record/lookml/block.rb
@@ -1,0 +1,27 @@
+module ActiveRecord
+  module LookML
+    class Block
+      def initialize(type:, name:)
+        @type = type
+        @name = name
+        @fields = []
+        yield(self) if block_given?
+      end
+
+      def <<(new_field)
+        @fields << new_field
+      end
+
+      def to_lookml(indent_level: 0)
+        indent = '  ' * indent_level
+        lookml = "#{indent}#{@type}: #{@name} {\n"
+        @fields.each_with_index do |field, index|
+          lookml << "\n" if index > 0 && field.is_a?(Block)
+          lookml << field.to_lookml(indent_level: indent_level + 1)
+        end
+        lookml << "#{indent}}\n"
+        lookml
+      end
+    end
+  end
+end

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -80,81 +80,55 @@ module ActiveRecord
         end
 
         def to_lookml(table_name_prefix: 'wantedly-1371.rdb.pulse_')
-          dimensions_lookml = attribute_types.map do |attribute, type|
-            attribute_type_to_dimension_lookml(attribute, type)
-          end.join("\n")
-
           fields = attribute_types.map do |attribute, type|
             attribute_type_to_set_detail_field(attribute, type)
           end.compact
-          fields_lookml = fields.map { |field| "      #{field}" }.join(",\n")
 
-          set_lookml = <<-LOOKML
-  set: detail {
-    fields: [
-#{fields_lookml}
-    ]
-  }
-          LOOKML
+          set_block = Block.new(type: "set", name: "detail") do |b|
+            b << ArrayField.new(name: "fields", values: fields)
+          end
 
-          <<-LOOKML
-view: pulse_onboarding_statuses {
-  sql_table_name: `#{table_name_prefix}#{table_name}`;;
-
-#{dimensions_lookml}
-#{set_lookml}}
-          LOOKML
+          Block.new(type: "view", name: "pulse_onboarding_statuses") do |b|
+            b << Field.new(name: "sql_table_name", value: "`#{table_name_prefix}#{table_name}`;;")
+            attribute_types.each do |attribute, type|
+              b << attribute_type_to_block(attribute, type)
+            end
+            b << set_block
+          end.to_lookml
         end
 
         private
-        def attribute_type_to_dimension_lookml(attribute, type)
+        def attribute_type_to_block(attribute, type)
           case type
           when ActiveModel::Type::Integer
-            params = {
-              type: "number",
-              primary_key: attribute == "id" ? "yes" : nil,
-              sql: "${TABLE}.#{attribute} ;;"
-            }.compact
-
-            params_lookml = params.map { |k, v| "    #{k}: #{v}" }.join("\n")
-
-            <<-LOOKML
-  dimension: #{attribute} {
-#{params_lookml}
-  }
-            LOOKML
+            Block.new(type: "dimension", name: attribute) do |b|
+              b << Field.new(name: "type", value: "number")
+              b << Field.new(name: "primary_key", value: "yes") if attribute == "id"
+              b << Field.new(name: "sql", value: "${TABLE}.#{attribute} ;;")
+            end
           when ActiveModel::Type::Boolean
-            <<-LOOKML
-  dimension: #{attribute} {
-    type: yesno
-    sql: ${TABLE}.#{attribute} ;;
-  }
-            LOOKML
+            Block.new(type: "dimension", name: attribute) do |b|
+              b << Field.new(name: "type", value: "yesno")
+              b << Field.new(name: "sql", value: "${TABLE}.#{attribute} ;;")
+            end
           when ActiveRecord::Type::DateTime, ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
-            <<-LOOKML
-  dimension_group: #{attribute} {
-    type: time
-    sql: ${TABLE}.#{attribute} ;;
-  }
-            LOOKML
+            Block.new(type: "dimension_group", name: attribute) do |b|
+              b << Field.new(name: "type", value: "time")
+              b << Field.new(name: "sql", value: "${TABLE}.#{attribute} ;;")
+            end
           when ActiveRecord::Enum::EnumType
             enum_values = defined_enums[attribute]
-            when_lines_lookml = enum_values.map do |label, value|
-              <<-LOOKML
-      when: {
-        sql: ${TABLE}.#{attribute} = #{value} ;;
-        label: "#{label}"
-      }
-              LOOKML
-            end.join
 
-            <<-LOOKML
-  dimension: #{attribute} {
-    case: {
-#{when_lines_lookml}
-    }
-  }
-            LOOKML
+            Block.new(type: "dimension", name: attribute) do |b|
+              b << Block.new(type: "case", name: nil) do |b|
+                enum_values.map do |label, value|
+                  b << Block.new(type: "when", name: nil) do |b|
+                    b << Field.new(name: "sql", value: "${TABLE}.#{attribute} = #{value} ;;")
+                    b << Field.new(name: "label", value: "\"#{label}\"")
+                  end
+                end
+              end
+            end
           else
             raise "Unknown attribute type: #{attribute} #{type.class}"
           end

--- a/lib/active_record/lookml/core.rb
+++ b/lib/active_record/lookml/core.rb
@@ -4,81 +4,6 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       module ClassMethods
-        # Generates LookML dimension from ruby hash.
-        #
-        # Input format:
-        #
-        # {"manager_tutorial_state"=>
-        #   {"start_tutorial"=>0,
-        #    "explain_condition_survay"=>1,
-        #    "ask_condition"=>2,
-        #    "explain_high_fives"=>3,
-        #    "try_high_fives"=>4,
-        #    "request_members_to_get_started"=>5,
-        #    "done_announce_to_member"=>6,
-        #    "done_tutorial"=>7}}
-        #
-        #
-        # Output format:
-        #
-        # dimension: manager_tutorial_state {
-        #   case: {
-        #       when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 0 ;;
-        #       label: "start_tutorial"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 1 ;;
-        #       label: "explain_condition_survay"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 2 ;;
-        #       label: "ask_condition"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 3 ;;
-        #       label: "explain_high_fives"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 4 ;;
-        #       label: "try_high_fives"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 5 ;;
-        #       label: "request_members_to_get_started"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 6 ;;
-        #       label: "done_announce_to_member"
-        #     }
-        #     when: {
-        #       sql: ${TABLE}.manager_tutorial_state = 7 ;;
-        #       label: "done_tutorial"
-        #     }
-        #   }
-        # }
-        # @see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/enum.rb
-        def enum_to_lookml
-          defined_enums.map do |name, enum_values|
-            when_lines_lookml = enum_values.map do |label, value|
-              <<-LOOKML
-      when: {
-        sql: ${TABLE}.#{name} = #{value} ;;
-        label: "#{label}"
-      }
-              LOOKML
-            end.join
-
-            <<-LOOKML
-  dimension: #{name} {
-    case: {
-  #{when_lines_lookml}
-    }
-  }
-            LOOKML
-          end.join("\n")
-        end
-
         def to_lookml(table_name_prefix: 'wantedly-1371.rdb.pulse_')
           fields = attribute_types.map do |attribute, type|
             attribute_type_to_set_detail_field(attribute, type)
@@ -117,6 +42,7 @@ module ActiveRecord
               b << Field.new(name: "sql", value: "${TABLE}.#{attribute} ;;")
             end
           when ActiveRecord::Enum::EnumType
+            # @see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/enum.rb
             enum_values = defined_enums[attribute]
 
             Block.new(type: "dimension", name: attribute) do |b|

--- a/lib/active_record/lookml/field.rb
+++ b/lib/active_record/lookml/field.rb
@@ -1,0 +1,15 @@
+module ActiveRecord
+  module LookML
+    class Field
+      def initialize(name:, value:)
+        @name = name
+        @value = value
+      end
+
+      def to_lookml(indent_level: 0)
+        indent = '  ' * indent_level
+        "#{indent}#{@name}: #{@value}\n"
+      end
+    end
+  end
+end

--- a/spec/active_record/lookml/block_spec.rb
+++ b/spec/active_record/lookml/block_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe ActiveRecord::LookML::Block do
+  describe "#to_lookml" do
+    subject { block.to_lookml }
+    let(:block) { ActiveRecord::LookML::Block.new(type: type, name: name) }
+
+    context "when block has no field" do
+      let(:type) { "view" }
+      let(:name) { "some_view_name" }
+      let(:lookml) {
+        <<~LOOKML
+          view: some_view_name {
+          }
+        LOOKML
+      }
+      it "retuns expected lookml" do
+        expect(subject).to eq lookml
+      end
+    end
+
+    context "when block has sub blocks as feilds" do
+      let(:type) { "view" }
+      let(:name) { "some_view_name" }
+      let(:lookml) {
+        <<~LOOKML
+          view: some_view_name {
+            dimension: user_id {
+            }
+
+            dimension: company_id {
+            }
+          }
+        LOOKML
+      }
+      it "retuns expected lookml" do
+        block << ActiveRecord::LookML::Block.new(type: "dimension", name: "user_id")
+        block << ActiveRecord::LookML::Block.new(type: "dimension", name: "company_id")
+        expect(subject).to eq lookml
+      end
+    end
+
+    context "when block has feilds" do
+      let(:type) { "dimension_group" }
+      let(:name) { "created_at" }
+      let(:lookml) {
+        <<~LOOKML
+          dimension_group: created_at {
+            type: time
+            sql: ${TABLE}.created_at ;;
+          }
+        LOOKML
+      }
+      it "retuns expected lookml" do
+        block << ActiveRecord::LookML::Field.new(name: "type", value: "time")
+        block << ActiveRecord::LookML::Field.new(name: "sql", value: "${TABLE}.created_at ;;")
+        expect(subject).to eq lookml
+      end
+    end
+  end
+end

--- a/spec/active_record/lookml/core_spec.rb
+++ b/spec/active_record/lookml/core_spec.rb
@@ -33,35 +33,41 @@ view: pulse_onboarding_statuses {
         sql: ${TABLE}.manager_tutorial_state = 0 ;;
         label: "start_tutorial"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 1 ;;
         label: "explain_condition_survey"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 2 ;;
         label: "ask_condition"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 3 ;;
         label: "explain_high_fives"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 4 ;;
         label: "try_high_fives"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 5 ;;
         label: "request_members_to_get_started"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 6 ;;
         label: "done_announce_to_member"
       }
+
       when: {
         sql: ${TABLE}.manager_tutorial_state = 7 ;;
         label: "done_tutorial"
       }
-
     }
   }
 
@@ -71,23 +77,26 @@ view: pulse_onboarding_statuses {
         sql: ${TABLE}.member_tutorial_state = 0 ;;
         label: "explain_condition_survey"
       }
+
       when: {
         sql: ${TABLE}.member_tutorial_state = 1 ;;
         label: "ask_condition"
       }
+
       when: {
         sql: ${TABLE}.member_tutorial_state = 2 ;;
         label: "explain_high_fives"
       }
+
       when: {
         sql: ${TABLE}.member_tutorial_state = 3 ;;
         label: "try_high_fives"
       }
+
       when: {
         sql: ${TABLE}.member_tutorial_state = 4 ;;
         label: "done_tutorial"
       }
-
     }
   }
 

--- a/spec/active_record/lookml/core_spec.rb
+++ b/spec/active_record/lookml/core_spec.rb
@@ -1,82 +1,8 @@
 require 'models/pulse_onboarding_status'
 
 RSpec.describe ActiveRecord::LookML::Core do
-  it "adds .enum_to_lookml method to ActiveRecord::Base" do
-    expect(ActiveRecord::Base.enum_to_lookml).to eq ""
-  end
-
-  describe ".enum_to_lookml" do
-    let(:lookml) do
-      <<-LOOKML
-  dimension: manager_tutorial_state {
-    case: {
-        when: {
-        sql: ${TABLE}.manager_tutorial_state = 0 ;;
-        label: "start_tutorial"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 1 ;;
-        label: "explain_condition_survey"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 2 ;;
-        label: "ask_condition"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 3 ;;
-        label: "explain_high_fives"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 4 ;;
-        label: "try_high_fives"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 5 ;;
-        label: "request_members_to_get_started"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 6 ;;
-        label: "done_announce_to_member"
-      }
-      when: {
-        sql: ${TABLE}.manager_tutorial_state = 7 ;;
-        label: "done_tutorial"
-      }
-
-    }
-  }
-
-  dimension: member_tutorial_state {
-    case: {
-        when: {
-        sql: ${TABLE}.member_tutorial_state = 0 ;;
-        label: "explain_condition_survey"
-      }
-      when: {
-        sql: ${TABLE}.member_tutorial_state = 1 ;;
-        label: "ask_condition"
-      }
-      when: {
-        sql: ${TABLE}.member_tutorial_state = 2 ;;
-        label: "explain_high_fives"
-      }
-      when: {
-        sql: ${TABLE}.member_tutorial_state = 3 ;;
-        label: "try_high_fives"
-      }
-      when: {
-        sql: ${TABLE}.member_tutorial_state = 4 ;;
-        label: "done_tutorial"
-      }
-
-    }
-  }
-      LOOKML
-    end
-
-    it "returns partial lookml defining dimensions for enum attributes" do
-      expect(PulseOnboardingStatus.enum_to_lookml).to eq lookml
-    end
+  it "adds .to_lookml method to ActiveRecord::Base" do
+    expect(ActiveRecord::Base.to_lookml).to eq ""
   end
 
   describe ".to_lookml" do

--- a/spec/active_record/lookml/core_spec.rb
+++ b/spec/active_record/lookml/core_spec.rb
@@ -2,7 +2,7 @@ require 'models/pulse_onboarding_status'
 
 RSpec.describe ActiveRecord::LookML::Core do
   it "adds .to_lookml method to ActiveRecord::Base" do
-    expect(ActiveRecord::Base.to_lookml).to eq ""
+    expect(ActiveRecord::Base.respond_to?(:to_lookml)).to be_truthy
   end
 
   describe ".to_lookml" do


### PR DESCRIPTION
## Why

It was cumbersome and messy to generate huge lookml string with many nested fields.

## What

Abstracted lookml with new classes, `Block`, `Field`, and `ArrayField` for easier string generation.